### PR TITLE
bug fix for graph intersection id inconsistency

### DIFF
--- a/app/src/main/assets/zoo_node_info.json
+++ b/app/src/main/assets/zoo_node_info.json
@@ -468,7 +468,7 @@
     "image_link": ""
   },
   {
-    "id": "intxn_primate_treetops",
+    "id": "intxn_primate_treetop",
     "kind": "intersection",
     "name": "Primate Path / Treetops Way",
     "tags": [],
@@ -504,7 +504,7 @@
     "image_link": ""
   },
   {
-    "id": "intxn_front_treetops",
+    "id": "intxn_front_treetop",
     "kind": "intersection",
     "name": "Front Street / Treetops Way",
     "tags": [],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Straightforward implementation without unnecessary complexity
- [x] Follows Coding Conventions
- [x] UI/UX is consistent with the rest of the application
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for app crashing when using Primate Path / Treetops Way inside direction


* **What is the current behavior?** (You can also link to an open issue here)
Inside ZooGraph.json file the intersection id are intxn_primate_treetop and intxn_front_treetop, but inside ZooNodeInfo it is intxn_primate_treetops and intxn_primate_treetops.


* **What is the new behavior (if this is a feature change)?**
Navigation shouldn't crash b/c the pathname not found.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: